### PR TITLE
Concrete5 version 8 support and kint version update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "raveren/kint": "^1.0"
+        "kint-php/kint": "^2.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,34 +4,37 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "256ef582a3d7e9c522c3bf09ee93776d",
+    "content-hash": "95d396855911e51e3844d50f61049cab",
     "packages": [
         {
-            "name": "raveren/kint",
-            "version": "1.0.6",
+            "name": "kint-php/kint",
+            "version": "2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/raveren/kint.git",
-                "reference": "0cb1329798c85df500e4dfac607c5d6834c18431"
+                "url": "https://github.com/kint-php/kint.git",
+                "reference": "d6b2540da2477ec8f4c5d6d30807208e5f814d75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/raveren/kint/zipball/0cb1329798c85df500e4dfac607c5d6834c18431",
-                "reference": "0cb1329798c85df500e4dfac607c5d6834c18431",
+                "url": "https://api.github.com/repos/kint-php/kint/zipball/d6b2540da2477ec8f4c5d6d30807208e5f814d75",
+                "reference": "d6b2540da2477ec8f4c5d6d30807208e5f814d75",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.1.0"
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "phpunit/phpunit": "^4.0",
+                "symfony/finder": "^2.6"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "files": [
-                    "Kint.class.php"
+                    "init.php"
+                ],
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -44,18 +47,22 @@
                     "homepage": "https://github.com/raveren"
                 },
                 {
+                    "name": "Jonathan Vollebregt",
+                    "homepage": "https://github.com/jnvsor"
+                },
+                {
                     "name": "Contributors",
-                    "homepage": "https://github.com/raveren/kint/contributors"
+                    "homepage": "https://github.com/kint-php/kint/graphs/contributors"
                 }
             ],
-            "description": "Kint - debugging helper for PHP developers",
-            "homepage": "https://github.com/raveren/kint",
+            "description": "Kint - debugging tool for PHP developers",
+            "homepage": "https://kint-php.github.io/kint/",
             "keywords": [
                 "debug",
                 "kint",
                 "php"
             ],
-            "time": "2015-07-02 11:06:58"
+            "time": "2017-04-22T13:41:40+00:00"
         }
     ],
     "packages-dev": [],

--- a/controller.php
+++ b/controller.php
@@ -8,23 +8,30 @@ use Config;
 
 defined('C5_EXECUTE') or die(_('Access Denied.'));
 
-$fs = new Filesystem();
-$fs->getRequire(__DIR__ . '/vendor/autoload.php');
+//$fs = new Filesystem();
+//$fs->getRequire(__DIR__ . '/vendor/autoload.php');
 
-class Controller extends Package {
+class Controller extends Package
+{
     protected $pkgHandle = 'kint_debug';
     protected $appVersionRequired = '5.7.0.4';
-    protected $pkgVersion = '0.9.5';
+    protected $pkgVersion = '0.9.6';
 
-    public function getPackageDescription() {
+    public function getPackageDescription()
+    {
         return t('Add Kint debugging tools');
     }
 
-    public function getPackageName() {
+    public function getPackageName()
+    {
         return t('Debug Kit');
     }
 
-    public function on_start() {
+    public function on_start()
+    {
+        // register autoloading
+        $this->registerAutoload();
+
         $al = \Concrete\Core\Asset\AssetList::getInstance();
         $al->register('css', $this->pkgHandle . '/css', 'css/debug.css', array(), $this->pkgHandle);
 
@@ -49,5 +56,13 @@ class Controller extends Package {
     protected function isAjaxRequest() {
         return !empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
             strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+    }
+
+    /**
+     * Register autoloader.
+     */
+    protected function registerAutoload()
+    {
+        require $this->getPackagePath().'/vendor/autoload.php';
     }
 }


### PR DESCRIPTION
Hi, I've updated the controller and the kint library to make compatible with concrete5 version 8 with updated kint library. I've checked and it's working fine for me.